### PR TITLE
fix(workflows): drop GH_PAT dependency; schedule-trigger gh-pages (#57)

### DIFF
--- a/.github/workflows/knowledge-gh-pages.yml
+++ b/.github/workflows/knowledge-gh-pages.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main # Or your primary development branch
+  schedule:
+    # Daily at 11:00 UTC — 30 min after the last daily data workflow (daily_discord_briefing at 10:30).
+    # Ensures deployment even when upstream commits are made via default GITHUB_TOKEN
+    # (which doesn't trigger push-event workflows).
+    - cron: '0 11 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -9,16 +9,19 @@ on:
 permissions:
   contents: write  # Allow pushing to the repository
 
+concurrency:
+  group: knowledge-repo-writes
+  cancel-in-progress: false
+
 jobs:
   sync-sources:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Fetch all history for proper comparisons
-          token: ${{ secrets.GH_PAT }}  # Use PAT for authentication
       
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
Fixes #57.

## Summary

- `.github/workflows/sync.yml` — remove `token: ${{ secrets.GH_PAT }}` from checkout; add `concurrency: knowledge-repo-writes` group to match peers.
- `.github/workflows/knowledge-gh-pages.yml` — add `schedule: cron '0 11 * * *'` trigger.

## Why

Sync has failed 6 consecutive days because the `GH_PAT` secret is expired. Pages stopped deploying the same day (last deploy 2026-04-11) because sync's PAT-based push was the sole trigger — default `GITHUB_TOKEN` pushes are deliberately blocked from triggering downstream workflows.

## Test plan

- [x] YAML parse both files
- [x] Confirm `GH_PAT` no longer referenced in sync.yml
- [x] Confirm `concurrency` group present in sync.yml
- [x] Confirm `schedule:` trigger present in knowledge-gh-pages.yml
- [ ] After merge: `gh workflow run sync.yml -R elizaOS/knowledge` and watch run succeed
- [ ] After merge: confirm next 11:00 UTC Pages deploy fires on schedule
- [ ] After verified: delete stale `GH_PAT` secret from repo settings (hygiene)

🤖 Generated with [Claude Code](https://claude.com/claude-code)