### PR TITLE
fix(workflows): reference alert-failure action by remote ref, not local path (#61)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -139,7 +139,7 @@ Standardized Python environment setup:
 #### `alert-failure`
 Standardized failure alerting to Discord:
 ```yaml
-- uses: ./.github/actions/alert-failure
+- uses: elizaOS/knowledge/.github/actions/alert-failure@main
   with:
     webhook-url: ${{ secrets.ALERT_WEBHOOK_URL }}
     workflow-name: 'Workflow Name'

--- a/.github/workflows/aggregate-daily-sources.yml
+++ b/.github/workflows/aggregate-daily-sources.yml
@@ -44,7 +44,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
       - name: Alert on failure
         if: failure()
-        uses: ./.github/actions/alert-failure
+        uses: elizaOS/knowledge/.github/actions/alert-failure@main
         with:
           webhook-url: ${{ secrets.ALERT_WEBHOOK_URL }}
           workflow-name: 'Aggregate Daily Sources'

--- a/.github/workflows/extract_daily_facts.yml
+++ b/.github/workflows/extract_daily_facts.yml
@@ -128,7 +128,7 @@ jobs:
 
       - name: Alert on failure
         if: failure()
-        uses: ./.github/actions/alert-failure
+        uses: elizaOS/knowledge/.github/actions/alert-failure@main
         with:
           webhook-url: ${{ secrets.ALERT_WEBHOOK_URL }}
           workflow-name: 'Extract Daily Facts'

--- a/.github/workflows/generate-council-briefing.yml
+++ b/.github/workflows/generate-council-briefing.yml
@@ -76,7 +76,7 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v5
       - name: Alert on failure
         if: failure()
-        uses: ./.github/actions/alert-failure
+        uses: elizaOS/knowledge/.github/actions/alert-failure@main
         with:
           webhook-url: ${{ secrets.ALERT_WEBHOOK_URL }}
           workflow-name: 'Generate Council Briefing'

--- a/.github/workflows/help-reports.yml
+++ b/.github/workflows/help-reports.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Alert on failure
         if: failure()
-        uses: ./.github/actions/alert-failure
+        uses: elizaOS/knowledge/.github/actions/alert-failure@main
         with:
           webhook-url: ${{ secrets.ALERT_WEBHOOK_URL }}
           workflow-name: 'Monthly Help Report'
@@ -107,7 +107,7 @@ jobs:
 
       - name: Alert on failure
         if: failure()
-        uses: ./.github/actions/alert-failure
+        uses: elizaOS/knowledge/.github/actions/alert-failure@main
         with:
           webhook-url: ${{ secrets.ALERT_WEBHOOK_URL }}
           workflow-name: 'Help Reports Backfill'

--- a/.github/workflows/retro.yml
+++ b/.github/workflows/retro.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Alert on failure
         if: failure()
-        uses: ./.github/actions/alert-failure
+        uses: elizaOS/knowledge/.github/actions/alert-failure@main
         with:
           webhook-url: ${{ secrets.ALERT_WEBHOOK_URL }}
           workflow-name: 'Monthly Retro'
@@ -110,7 +110,7 @@ jobs:
 
       - name: Alert on failure
         if: failure()
-        uses: ./.github/actions/alert-failure
+        uses: elizaOS/knowledge/.github/actions/alert-failure@main
         with:
           webhook-url: ${{ secrets.ALERT_WEBHOOK_URL }}
           workflow-name: 'Quarterly Summary'
@@ -148,7 +148,7 @@ jobs:
 
       - name: Alert on failure
         if: failure()
-        uses: ./.github/actions/alert-failure
+        uses: elizaOS/knowledge/.github/actions/alert-failure@main
         with:
           webhook-url: ${{ secrets.ALERT_WEBHOOK_URL }}
           workflow-name: 'Annual Summary'

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -140,7 +140,7 @@ jobs:
 
       - name: Alert on failure
         if: failure()
-        uses: ./.github/actions/alert-failure
+        uses: elizaOS/knowledge/.github/actions/alert-failure@main
         with:
           webhook-url: ${{ secrets.ALERT_WEBHOOK_URL }}
           workflow-name: 'Sync Knowledge Sources'


### PR DESCRIPTION
Fixes #61.

## Summary

Replace `uses: ./.github/actions/alert-failure` with `uses: elizaOS/knowledge/.github/actions/alert-failure@main` across all 9 call sites (plus one doc example in `workflows/README.md`).

## Why

Local-path action references require the working tree to be populated. When `actions/checkout` fails — which is exactly the worst-case silent-outage scenario — the `Alert on failure` step also fails to load `action.yml` from disk. Remote-ref `uses:` bypasses the working tree entirely; GitHub fetches the action via the Actions API.

This is the failure mode that hid the 6-day sync.yml outage (issue #57) from all monitoring.

## Test plan

- [x] YAML parses clean on all 7 modified workflows
- [x] Grep confirms zero remaining `uses: \./\.github/actions/alert-failure` references
- [ ] After merge: on a throwaway branch, swap `token: \${{ secrets.DOES_NOT_EXIST }}` into a workflow's checkout step, confirm the Discord alert fires despite checkout failure

## Trade-off

PR changes to the `alert-failure` action itself will not be self-testable on the PR that introduces them — the `@main` pin still points at merged main. Acceptable given the action changes rarely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple GitHub Actions workflows to reference a centralized remote action for failure notifications instead of local action definitions. This consolidates failure alert management, improves configuration consistency across automation pipelines, and simplifies ongoing maintenance. All alert behavior and inputs remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->