### PR TITLE
fix(retro): compute year/quarter defaults for scheduled runs (#63)

### DIFF
--- a/.github/workflows/retro.yml
+++ b/.github/workflows/retro.yml
@@ -96,10 +96,21 @@ jobs:
         env:
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
         run: |
-          ARGS=""
-          [ -n "${{ inputs.year }}" ] && ARGS="$ARGS -y ${{ inputs.year }}"
-          [ -n "${{ inputs.quarter }}" ] && ARGS="$ARGS -q ${{ inputs.quarter }}"
-          python scripts/etl/generate-quarterly-summary.py $ARGS
+          YEAR="${{ inputs.year }}"
+          QUARTER="${{ inputs.quarter }}"
+
+          PREV_MONTH_DATE=$(date -d "$(date +%Y-%m-01) -1 month" +%Y-%m-01)
+          PREV_YEAR=$(date -d "$PREV_MONTH_DATE" +%Y)
+          PREV_QUARTER=$(( ($(date -d "$PREV_MONTH_DATE" +%-m) - 1) / 3 + 1 ))
+
+          [ -z "$QUARTER" ] && QUARTER="$PREV_QUARTER"
+
+          if [ -z "$YEAR" ]; then
+            YEAR="$PREV_YEAR"
+            [ "$QUARTER" -gt "$PREV_QUARTER" ] && YEAR=$((YEAR - 1))
+          fi
+
+          python scripts/etl/generate-quarterly-summary.py -y "$YEAR" -q "$QUARTER"
 
       - uses: stefanzweifel/git-auto-commit-action@v5
         with:


### PR DESCRIPTION
Fixes #63.

## Summary

The `generate-quarterly` job failed on the 2026-04-01 scheduled fire with `error: the following arguments are required: -y/--year`. Fix mirrors the auto-compute pattern used by the monthly and annual jobs.

## Test plan

7 scenarios simulated locally — all correct:

| Today | input.year | input.quarter | → | Expected |
|---|---|---|---|---|
| 2026-04-01 | ∅ | ∅ | `-y 2026 -q 1` | Q1 2026 ✓ |
| 2026-07-01 | ∅ | ∅ | `-y 2026 -q 2` | Q2 2026 ✓ |
| 2027-01-01 | ∅ | ∅ | `-y 2026 -q 4` | Q4 2026 (rollover) ✓ |
| 2026-04-18 | ∅ | ∅ | `-y 2026 -q 1` | Q1 2026 ✓ |
| 2026-04-18 | 2025 | ∅ | `-y 2025 -q 1` | Q1 2025 ✓ |
| 2026-01-15 | ∅ | 4 | `-y 2025 -q 4` | Q4 2025 (rollover) ✓ |
| 2026-04-18 | 2024 | 3 | `-y 2024 -q 3` | Q3 2024 ✓ |

Next scheduled fire: 2026-07-01 04:00 UTC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)