### PR TITLE
chore(workflows): minor cleanups — env vars, silent rebase, duplicate RSS (#65)

### DIFF
--- a/.github/workflows/aggregate-daily-sources.yml
+++ b/.github/workflows/aggregate-daily-sources.yml
@@ -34,8 +34,6 @@ jobs:
       - name: Generate Daily Context Map
         id: generate_map
         run: python scripts/etl/aggregate-sources.py
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # GITHUB_TOKEN is usually not needed by the script itself
 
       - name: Create daily.json permalink
         run: cp the-council/aggregated/$(date +%Y-%m-%d).json the-council/aggregated/daily.json

--- a/.github/workflows/daily_discord_briefing.yml
+++ b/.github/workflows/daily_discord_briefing.yml
@@ -6,6 +6,9 @@ on:
     - cron: '30 10 * * *'
   workflow_dispatch: # Allows manual triggering
 
+env:
+  DISCORD_FACTS_CHANNEL_ID: ${{ vars.DISCORD_FACTS_CHANNEL_ID || '1377401701081944144' }}
+
 jobs:
   send-daily-briefing:
     runs-on: ubuntu-latest
@@ -44,4 +47,4 @@ jobs:
           fi
 
           echo "Sending briefing using: $FACTS_FILE"
-          python scripts/integrations/discord/webhook.py "$FACTS_FILE" -d -c "1377401701081944144" -s
+          python scripts/integrations/discord/webhook.py "$FACTS_FILE" -d -c "$DISCORD_FACTS_CHANNEL_ID" -s

--- a/.github/workflows/generate-council-briefing.yml
+++ b/.github/workflows/generate-council-briefing.yml
@@ -68,10 +68,6 @@ jobs:
         if: steps.council_gen.outputs.council_json_file
         run: cp "${{ steps.council_gen.outputs.council_json_file }}" the-council/council_briefing/daily.json
 
-      - name: Generate RSS feeds
-        run: |
-          python scripts/etl/generate-rss.py
-
       - name: Commit updated files
         uses: stefanzweifel/git-auto-commit-action@v5
       - name: Alert on failure

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Commit and push changes
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "Daily Knowledge Sync: $(date +%Y-%m-%d)"
+          commit_message: "Daily Knowledge Sync"
           file_pattern: "docs/ github/ daily-silk/ ai-news/ clanktank/ the-council/"
           commit_user_name: "github-actions[bot]"
           commit_user_email: "github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/update_hackmd_notes.yml
+++ b/.github/workflows/update_hackmd_notes.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Pull latest changes before commit
         run: |
           git fetch origin main
-          git rebase origin/main || git rebase --abort
+          git rebase origin/main || { git rebase --abort; exit 1; }
 
       - name: Commit updated files
         uses: stefanzweifel/git-auto-commit-action@v5


### PR DESCRIPTION
Fixes #65.

## Summary

Five low-risk cleanups bundled:

| # | File | Change |
|---|---|---|
| 1 | `daily_discord_briefing.yml` | Hardcoded channel ID → `vars.DISCORD_FACTS_CHANNEL_ID` (fallback to current value) |
| 2 | `generate-council-briefing.yml` | Remove duplicate `generate-rss.py` call; `generate-posters.yml` runs it later |
| 3 | `update_hackmd_notes.yml` | Rebase conflict fails loud instead of continuing silently |
| 4 | `aggregate-daily-sources.yml` | Drop unused `GITHUB_TOKEN` env on script step |
| 5 | `sync.yml` | Commit message drops literal `$(date +%Y-%m-%d)` (not shell-evaluated by git-auto-commit-action) |

## Test plan

- [x] YAML parse all 5 modified files
- [ ] After merge: `vars.DISCORD_FACTS_CHANNEL_ID` can be set in repo settings → Variables to override without editing the workflow (optional — default matches current hardcoded value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)