### PR TITLE
Fix council briefing validation and backfill safety

### DIFF
--- a/.github/workflows/generate-council-briefing.yml
+++ b/.github/workflows/generate-council-briefing.yml
@@ -66,7 +66,10 @@ jobs:
 
       - name: Create council_context_daily.json permalink
         if: steps.council_gen.outputs.council_json_file
-        run: cp "${{ steps.council_gen.outputs.council_json_file }}" the-council/council_briefing/daily.json
+        run: |
+          python scripts/etl/validate-council-briefing.py "${{ steps.council_gen.outputs.council_json_file }}"
+          cp "${{ steps.council_gen.outputs.council_json_file }}" the-council/council_briefing/daily.json
+          python scripts/etl/validate-council-briefing.py the-council/council_briefing/daily.json
 
       - name: Commit updated files
         uses: stefanzweifel/git-auto-commit-action@v5

--- a/.github/workflows/knowledge-gh-pages.yml
+++ b/.github/workflows/knowledge-gh-pages.yml
@@ -28,6 +28,9 @@ jobs:
         with:
           ref: main
 
+      - name: Validate council briefing consumer contract
+        run: python scripts/etl/validate-council-briefing.py --consumer-only the-council/council_briefing/*.json
+
       - name: Prepare Staging Directory
         run: |
           mkdir -p ./gh-pages-staging

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -167,11 +167,16 @@ FORCE=1 ./scripts/etl/backfill/backfill-facts.sh 2026-01-09 2026-01-12
 
 ### `backfill/backfill-council.sh`
 
-**Purpose**: Backfills missing council briefings for a date range.
+**Purpose**: Backfills missing council briefings for a date range. Existing valid
+briefings are skipped; malformed V2 briefings are detected and regenerated.
 
 **Usage**:
 ```bash
 ./scripts/etl/backfill/backfill-council.sh 2026-01-09 2026-01-12
+
+# Audit historical files without making API calls
+python scripts/etl/validate-council-briefing.py --allow-legacy \
+  the-council/council_briefing/20*.json
 
 # Force overwrite
 FORCE=1 ./scripts/etl/backfill/backfill-council.sh 2026-01-09 2026-01-12

--- a/scripts/etl/backfill/backfill-council.sh
+++ b/scripts/etl/backfill/backfill-council.sh
@@ -13,6 +13,7 @@
 # Each date takes ~30-60 seconds depending on API response time.
 
 set -e
+set -o pipefail
 
 if [ -z "$OPENROUTER_API_KEY" ]; then
     echo "ERROR: OPENROUTER_API_KEY environment variable is not set"
@@ -84,18 +85,23 @@ for DATE in "${DATES[@]}"; do
         continue
     fi
 
-    # Check if output already exists (skip unless FORCE=1)
+    # Skip healthy existing output unless FORCE=1. Invalid V2 output is
+    # regenerated automatically, making this command safe for repair backfills.
     if [ -f "$OUTPUT_JSON" ] && [ "$FORCE" != "1" ]; then
-        echo "SKIP (already exists)"
-        SKIPPED=$((SKIPPED + 1))
-        continue
+        if python scripts/etl/validate-council-briefing.py --allow-legacy "$OUTPUT_JSON" >/dev/null 2>&1; then
+            echo "SKIP (already exists and is valid)"
+            SKIPPED=$((SKIPPED + 1))
+            continue
+        fi
+        echo -n "REPAIR (existing file is invalid)... "
     fi
 
     # Ensure output directory exists
     mkdir -p "the-council/council_briefing"
 
     # Run the generation
-    if python scripts/etl/generate-council-context.py "$INPUT_FILE" "$OUTPUT_JSON" 2>&1 | tail -1; then
+    if python scripts/etl/generate-council-context.py "$INPUT_FILE" "$OUTPUT_JSON" 2>&1 | tail -1 && \
+       python scripts/etl/validate-council-briefing.py "$OUTPUT_JSON" >/dev/null; then
         SUCCESS=$((SUCCESS + 1))
     else
         echo "FAILED"
@@ -117,6 +123,15 @@ echo "========================================"
 # Update daily.json permalink to latest date
 LATEST=$(ls -1 the-council/council_briefing/20*.json 2>/dev/null | grep -v daily | sort | tail -1)
 if [ -n "$LATEST" ]; then
-    cp "$LATEST" "the-council/council_briefing/daily.json"
-    echo "Updated daily.json to: $(basename "$LATEST")"
+    if python scripts/etl/validate-council-briefing.py --allow-legacy "$LATEST" >/dev/null; then
+        cp "$LATEST" "the-council/council_briefing/daily.json"
+        echo "Updated daily.json to: $(basename "$LATEST")"
+    else
+        echo "WARNING: Latest briefing is invalid; daily.json was preserved"
+        FAILED=$((FAILED + 1))
+    fi
+fi
+
+if [ "$FAILED" -gt 0 ]; then
+    exit 1
 fi

--- a/scripts/etl/council_schema.py
+++ b/scripts/etl/council_schema.py
@@ -1,0 +1,145 @@
+"""Validation helpers for the council briefing JSON consumed by downstream sites."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+QUESTION_ID_PATTERN = re.compile(r"q[1-9][0-9]*$")
+ANSWER_KEYS = {"answer_1", "answer_2", "answer_3"}
+PUBLISHED_ANSWER_KEYS = ANSWER_KEYS | {"answer_4"}
+
+
+class CouncilValidationError(ValueError):
+    """Raised when a council briefing does not satisfy the V2 contract."""
+
+
+def _require_string(value: Any, path: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise CouncilValidationError(f"{path} must be a non-empty string")
+
+
+def is_legacy_briefing(data: Any) -> bool:
+    """Return whether data uses the pre-V2 key_points format."""
+    if not isinstance(data, dict) or not isinstance(data.get("key_points"), list):
+        return False
+    points = data["key_points"]
+    return bool(points) and isinstance(points[0], dict) and "theme" in points[0]
+
+
+def validate_consumer_contract(data: Any) -> None:
+    """Validate fields dereferenced by the Astro council page renderer.
+
+    Historical files span multiple schemas, so this compatibility check ignores
+    legacy points and error placeholders while strictly checking every V2
+    deliberation item that a consumer will render.
+    """
+    if not isinstance(data, dict) or not isinstance(data.get("key_points"), list):
+        raise CouncilValidationError("briefing.key_points must be an array")
+    for point_index, point in enumerate(data["key_points"]):
+        if not isinstance(point, dict):
+            raise CouncilValidationError(f"key_points[{point_index}] must be an object")
+        if "deliberation_items" not in point:
+            continue
+        items = point["deliberation_items"]
+        if not isinstance(items, list):
+            raise CouncilValidationError(
+                f"key_points[{point_index}].deliberation_items must be an array"
+            )
+        for item_index, item in enumerate(items):
+            path = f"key_points[{point_index}].deliberation_items[{item_index}]"
+            if not isinstance(item, dict):
+                raise CouncilValidationError(f"{path} must be an object")
+            _require_string(item.get("question_id"), f"{path}.question_id")
+
+
+def validate_council_briefing(
+    data: Any,
+    *,
+    expected_date: str | None = None,
+    generated: bool = False,
+) -> None:
+    """Validate the V2 briefing structure.
+
+    ``generated=True`` validates the raw model response, which must contain exactly
+    three answer choices. Published briefings may additionally contain the
+    programmatically-added ``answer_4`` fallback.
+    """
+    if not isinstance(data, dict):
+        raise CouncilValidationError("briefing must be a JSON object")
+
+    for field in ("date", "meeting_context", "monthly_goal", "daily_focus"):
+        _require_string(data.get(field), field)
+    if expected_date is not None and data["date"] != expected_date:
+        raise CouncilValidationError(
+            f"date must match output date {expected_date!r}, got {data['date']!r}"
+        )
+
+    points = data.get("key_points")
+    if not isinstance(points, list) or not points:
+        raise CouncilValidationError("key_points must be a non-empty array")
+
+    seen_question_ids: set[str] = set()
+    for point_index, point in enumerate(points):
+        point_path = f"key_points[{point_index}]"
+        if not isinstance(point, dict):
+            raise CouncilValidationError(f"{point_path} must be an object")
+        _require_string(point.get("topic"), f"{point_path}.topic")
+        _require_string(point.get("summary"), f"{point_path}.summary")
+
+        items = point.get("deliberation_items")
+        if not isinstance(items, list) or not items:
+            raise CouncilValidationError(
+                f"{point_path}.deliberation_items must be a non-empty array"
+            )
+
+        for item_index, item in enumerate(items):
+            item_path = f"{point_path}.deliberation_items[{item_index}]"
+            if not isinstance(item, dict):
+                raise CouncilValidationError(f"{item_path} must be an object")
+
+            question_id = item.get("question_id")
+            _require_string(question_id, f"{item_path}.question_id")
+            if not QUESTION_ID_PATTERN.fullmatch(question_id):
+                raise CouncilValidationError(
+                    f"{item_path}.question_id must match q1, q2, ..."
+                )
+            if generated and question_id in seen_question_ids:
+                raise CouncilValidationError(f"duplicate question_id {question_id!r}")
+            seen_question_ids.add(question_id)
+            _require_string(item.get("text"), f"{item_path}.text")
+
+            context = item.get("context")
+            if context is not None:
+                if not isinstance(context, list):
+                    raise CouncilValidationError(f"{item_path}.context must be an array")
+                for context_index, context_item in enumerate(context):
+                    _require_string(
+                        context_item, f"{item_path}.context[{context_index}]"
+                    )
+
+            answers = item.get("multiple_choice_answers")
+            if not isinstance(answers, dict):
+                raise CouncilValidationError(
+                    f"{item_path}.multiple_choice_answers must be an object"
+                )
+            expected_keys = ANSWER_KEYS if generated else PUBLISHED_ANSWER_KEYS
+            if generated:
+                keys_are_valid = set(answers) == expected_keys
+            else:
+                keys_are_valid = set(answers) in (ANSWER_KEYS, PUBLISHED_ANSWER_KEYS)
+            if not keys_are_valid:
+                raise CouncilValidationError(
+                    f"{item_path}.multiple_choice_answers has invalid keys: "
+                    f"{sorted(answers)}"
+                )
+
+            for answer_key, answer in answers.items():
+                answer_path = f"{item_path}.multiple_choice_answers.{answer_key}"
+                if not isinstance(answer, dict):
+                    raise CouncilValidationError(f"{answer_path} must be an object")
+                _require_string(answer.get("text"), f"{answer_path}.text")
+                implication = answer.get("implication")
+                if implication is not None:
+                    _require_string(implication, f"{answer_path}.implication")

--- a/scripts/etl/generate-council-context.py
+++ b/scripts/etl/generate-council-context.py
@@ -344,12 +344,6 @@ def main():
         "messages": [{"role": "user", "content": prompt}]
     }
 
-    council_context_json = None
-    council_context_md = None
-    error_output_json = None
-    error_output_md = None
-    generation_succeeded = False
-
     # Metadata for observability
     council_metadata = {
         "model": MODEL,
@@ -405,72 +399,34 @@ def main():
         council_metadata["total_deliberation_questions"] = total_questions
         council_context_json["_metadata"] = council_metadata
         validate_council_briefing(council_context_json, expected_date=date_str)
-        generation_succeeded = True
 
     except requests.exceptions.RequestException as e:
         print(f"Error calling OpenRouter API for V2: {e}", file=sys.stderr)
-        council_metadata["status"] = "error"
-        council_metadata["error"] = f"API Request Failed: {e}"
-        council_metadata["processing_seconds"] = round((datetime.now(timezone.utc) - generation_start_time).total_seconds(), 2)
-        error_output_json = {"date": date_str, "monthly_goal": MONTHLY_GOAL, "daily_focus_theme": f"Error V2: API Request Failed ({e})", "key_strategic_points": [], "_metadata": council_metadata}
-        error_output_md = f"# Council Briefing (V2): {date_str}\n\nError: API Request Failed ({e})"
+        print("Generation failed; existing output files were preserved.", file=sys.stderr)
+        sys.exit(1)
     except (json.JSONDecodeError, ValueError, KeyError, IndexError) as e:
         print(f"Error processing LLM response for V2: {e}", file=sys.stderr)
         if 'response' in locals() and response is not None:
              print(f"LLM Response Data (V2): {response.text[:500]}...", file=sys.stderr)
-        council_metadata["status"] = "error"
-        council_metadata["error"] = f"Invalid LLM Response: {e}"
-        council_metadata["processing_seconds"] = round((datetime.now(timezone.utc) - generation_start_time).total_seconds(), 2)
-        error_output_json = {"date": date_str, "monthly_goal": MONTHLY_GOAL, "daily_focus_theme": f"Error V2: Invalid LLM Response ({e})", "key_strategic_points": [], "_metadata": council_metadata}
-        error_output_md = f"# Council Briefing (V2): {date_str}\n\nError: Invalid LLM Response ({e})"
+        print("Generation failed; existing output files were preserved.", file=sys.stderr)
+        sys.exit(1)
     except Exception as e:
-         print(f"An unexpected error occurred during V2 generation: {e}", file=sys.stderr)
-         council_metadata["status"] = "error"
-         council_metadata["error"] = f"Unexpected error: {e}"
-         council_metadata["processing_seconds"] = round((datetime.now(timezone.utc) - generation_start_time).total_seconds(), 2)
-         error_output_json = {"date": date_str, "monthly_goal": MONTHLY_GOAL, "daily_focus_theme": f"Error V2: Unexpected error ({e})", "key_strategic_points": [], "_metadata": council_metadata}
-         error_output_md = f"# Council Briefing (V2): {date_str}\n\nError: Unexpected error ({e})"
-    finally:
-        # Never replace a healthy dated briefing with an invalid model response or
-        # an error placeholder. The workflow will fail and can retry/backfill it.
-        if not generation_succeeded:
-            print("Generation failed; existing output files were preserved.", file=sys.stderr)
-            sys.exit(1)
+        print(f"An unexpected error occurred during V2 generation: {e}", file=sys.stderr)
+        print("Generation failed; existing output files were preserved.", file=sys.stderr)
+        sys.exit(1)
 
-        final_json_to_save = council_context_json if council_context_json else error_output_json
-        final_md_to_save = council_context_md if council_context_md else error_output_md
-        
-        if final_json_to_save is None:
-            print("Critical error: No JSON data (success or error) to save.", file=sys.stderr)
-            sys.exit(1)
-        if final_md_to_save is None:
-            print("Critical error: No Markdown data (success or error) to save.", file=sys.stderr)
-            if final_json_to_save:
-                 try:
-                    with open(output_path, 'w') as f_json:
-                        json.dump(final_json_to_save, f_json, indent=2, ensure_ascii=True)
-                    print(f"Saved V2 council context JSON (despite MD error) to: {output_path}")
-                 except Exception as e_json_write:
-                    print(f"Error writing final V2 JSON output file during MD error: {e_json_write}", file=sys.stderr)
-            sys.exit(1)
+    try:
+        atomic_write(
+            output_path,
+            json.dumps(council_context_json, indent=2, ensure_ascii=True) + "\n",
+        )
+        print(f"Saved V2 council context JSON to: {output_path}")
 
-        try:
-            atomic_write(
-                output_path,
-                json.dumps(final_json_to_save, indent=2, ensure_ascii=True) + "\n",
-            )
-            print(f"Saved V2 council context JSON to: {output_path}")
-
-            atomic_write(output_markdown_path, final_md_to_save)
-            print(f"Saved V2 council context Markdown to: {output_markdown_path}")
-
-            if not council_context_json:
-                 print("Exiting with error code due to V2 context generation failure.")
-                 sys.exit(1)
-
-        except Exception as e:
-            print(f"Error writing final V2 output files: {e}", file=sys.stderr)
-            sys.exit(1)
+        atomic_write(output_markdown_path, council_context_md)
+        print(f"Saved V2 council context Markdown to: {output_markdown_path}")
+    except Exception as e:
+        print(f"Error writing final V2 output files: {e}", file=sys.stderr)
+        sys.exit(1)
 
 if __name__ == "__main__":
     main()

--- a/scripts/etl/generate-council-context.py
+++ b/scripts/etl/generate-council-context.py
@@ -5,8 +5,11 @@ import sys
 import json
 import requests
 import argparse
+import tempfile
 from pathlib import Path
 from datetime import datetime, timezone
+
+from council_schema import validate_council_briefing
 
 # --- Configuration ---
 MODEL = "google/gemini-3-flash-preview"
@@ -28,6 +31,22 @@ MONTHLY_GOAL = os.environ.get(
     "December 2025: Execution excellence—complete token migration with high success rate, launch ElizaOS Cloud, stabilize flagship agents, and build developer trust through reliability and clear documentation."
 )
 # --- End Configuration ---
+
+
+def atomic_write(path: Path, content: str) -> None:
+    """Write content without exposing a partial or failed generation."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w", dir=path.parent, prefix=f".{path.name}.", delete=False
+        ) as temporary_file:
+            temporary_file.write(content)
+            temporary_path = Path(temporary_file.name)
+        os.replace(temporary_path, path)
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            temporary_path.unlink()
 
 def format_json_to_markdown(council_data):
     """Formats the council context JSON (Final V2 schema) into a Markdown string."""
@@ -236,7 +255,7 @@ def main():
     # --- Add Markdown output path ---
     output_markdown_dir = WORKSPACE_ROOT / "hackmd" / "council"
     output_markdown_dir.mkdir(parents=True, exist_ok=True)
-    markdown_filename = input_path.stem + ".md"
+    markdown_filename = output_path.stem + ".md"
     output_markdown_path = output_markdown_dir / markdown_filename
 
     # --- Validations ---
@@ -276,33 +295,39 @@ def main():
     content_list = [text_val for path, text_val in extracted_text_tuples]
     aggregated_content = "\n\n---\n\n".join(content_list)
 
+    # daily.json is a supported input fallback, so prefer its embedded date. This
+    # also prevents stale daily data from being published under today's filename.
+    source_date = lean_data.get("date_generated_for")
     try:
-        date_str = datetime.strptime(input_path.stem, "%Y-%m-%d").strftime("%Y-%m-%d")
+        date_str = datetime.strptime(
+            source_date if isinstance(source_date, str) else input_path.stem,
+            "%Y-%m-%d",
+        ).strftime("%Y-%m-%d")
     except ValueError:
-        print(f"Warning: Could not parse date from filename '{input_path.stem}'. Using placeholder.")
-        date_str = "unknown-date"
+        print(
+            f"Error: Could not determine a date from '{input_path}' or date_generated_for.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    try:
+        output_date = datetime.strptime(output_path.stem, "%Y-%m-%d").strftime("%Y-%m-%d")
+    except ValueError:
+        output_date = None
+    if output_date is not None and output_date != date_str:
+        print(
+            f"Error: Input data is for {date_str}, but output path is for {output_date}; "
+            "refusing to publish stale data.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     if not aggregated_content:
-        print("Warning: No content found in the input JSON file. Creating empty V2 output.", file=sys.stderr)
-        empty_output_json = {
-            "date": date_str,
-            "strategic_context_summary": "N/A - No operational data processed.",
-            "monthly_goal": MONTHLY_GOAL,
-            "daily_focus_theme": "No operational data processed.",
-            "key_strategic_points": []
-        }
-        empty_output_md = f"# Council Briefing (V2): {date_str}\n\nNo operational data processed."
-        try:
-            with open(output_path, 'w') as f:
-                json.dump(empty_output_json, f, indent=2, ensure_ascii=True)
-            with open(output_markdown_path, 'w') as f:
-                f.write(empty_output_md)
-            print(f"Saved empty V2 council context JSON to: {output_path}")
-            print(f"Saved empty V2 council context Markdown to: {output_markdown_path}")
-            sys.exit(0)
-        except Exception as e:
-            print(f"Error writing empty V2 output files: {e}", file=sys.stderr)
-            sys.exit(1)
+        print(
+            "Error: No content found in the input JSON; existing outputs were preserved.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     prompt = construct_prompt(strategic_context, MONTHLY_GOAL, date_str, aggregated_content)
 
@@ -323,6 +348,7 @@ def main():
     council_context_md = None
     error_output_json = None
     error_output_md = None
+    generation_succeeded = False
 
     # Metadata for observability
     council_metadata = {
@@ -351,40 +377,10 @@ def main():
 
         council_context_json = json.loads(council_context_str)
 
-        # FINAL Schema Validation
-        if not isinstance(council_context_json, dict) or \
-           "date" not in council_context_json or \
-           "meeting_context" not in council_context_json or \
-           "monthly_goal" not in council_context_json or \
-           "daily_focus" not in council_context_json or \
-           "key_points" not in council_context_json or \
-           not isinstance(council_context_json["key_points"], list):
-            raise ValueError("LLM response JSON is missing top-level V2 keys or key_points is not a list.")
-
-        for point in council_context_json["key_points"]:
-            if not isinstance(point, dict) or \
-               "topic" not in point or \
-               "summary" not in point or \
-               "deliberation_items" not in point or \
-               not isinstance(point["deliberation_items"], list):
-                raise ValueError("A key_point is missing keys (topic, summary, deliberation_items) or deliberation_items is not a list.")
-            
-            for item_val_loop in point["deliberation_items"]:
-                if not isinstance(item_val_loop, dict) or \
-                   "question_id" not in item_val_loop or \
-                   "text" not in item_val_loop or \
-                   "multiple_choice_answers" not in item_val_loop or \
-                   not isinstance(item_val_loop["multiple_choice_answers"], dict): # Check if it's a dictionary
-                    if "context" in item_val_loop and not isinstance(item_val_loop["context"], list):
-                        raise ValueError("A deliberation_item has an invalid context (must be a list if present).")
-                    raise ValueError("A deliberation_item is missing keys (question_id, text, multiple_choice_answers) or multiple_choice_answers is not a dict.")
-                
-                for answer_key, answer_obj in item_val_loop["multiple_choice_answers"].items():
-                    if not isinstance(answer_obj, dict) or \
-                       "text" not in answer_obj: # 'implication' is optional
-                        raise ValueError(f"A multiple_choice_answer ('{answer_key}') is missing 'text'.")
-                    if "implication" in answer_obj and not isinstance(answer_obj["implication"], str):
-                         raise ValueError(f"A multiple_choice_answer ('{answer_key}') has an invalid 'implication' (must be a string if present).")
+        # Validate the complete consumer contract, not just top-level JSON syntax.
+        validate_council_briefing(
+            council_context_json, expected_date=date_str, generated=True
+        )
 
         # Programmatically add the "Other" option to multiple_choice_answers
         for point in council_context_json["key_points"]:
@@ -408,6 +404,8 @@ def main():
         )
         council_metadata["total_deliberation_questions"] = total_questions
         council_context_json["_metadata"] = council_metadata
+        validate_council_briefing(council_context_json, expected_date=date_str)
+        generation_succeeded = True
 
     except requests.exceptions.RequestException as e:
         print(f"Error calling OpenRouter API for V2: {e}", file=sys.stderr)
@@ -433,6 +431,12 @@ def main():
          error_output_json = {"date": date_str, "monthly_goal": MONTHLY_GOAL, "daily_focus_theme": f"Error V2: Unexpected error ({e})", "key_strategic_points": [], "_metadata": council_metadata}
          error_output_md = f"# Council Briefing (V2): {date_str}\n\nError: Unexpected error ({e})"
     finally:
+        # Never replace a healthy dated briefing with an invalid model response or
+        # an error placeholder. The workflow will fail and can retry/backfill it.
+        if not generation_succeeded:
+            print("Generation failed; existing output files were preserved.", file=sys.stderr)
+            sys.exit(1)
+
         final_json_to_save = council_context_json if council_context_json else error_output_json
         final_md_to_save = council_context_md if council_context_md else error_output_md
         
@@ -451,12 +455,13 @@ def main():
             sys.exit(1)
 
         try:
-            with open(output_path, 'w') as f:
-                json.dump(final_json_to_save, f, indent=2, ensure_ascii=True)
+            atomic_write(
+                output_path,
+                json.dumps(final_json_to_save, indent=2, ensure_ascii=True) + "\n",
+            )
             print(f"Saved V2 council context JSON to: {output_path}")
 
-            with open(output_markdown_path, 'w') as f:
-                f.write(final_md_to_save)
+            atomic_write(output_markdown_path, final_md_to_save)
             print(f"Saved V2 council context Markdown to: {output_markdown_path}")
 
             if not council_context_json:

--- a/scripts/etl/test_council_schema.py
+++ b/scripts/etl/test_council_schema.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import copy
+import unittest
+
+from council_schema import (
+    CouncilValidationError,
+    validate_consumer_contract,
+    validate_council_briefing,
+)
+
+
+def valid_briefing():
+    return {
+        "date": "2026-06-16",
+        "meeting_context": "context",
+        "monthly_goal": "goal",
+        "daily_focus": "focus",
+        "key_points": [
+            {
+                "topic": "topic",
+                "summary": "summary",
+                "deliberation_items": [
+                    {
+                        "question_id": "q1",
+                        "text": "question",
+                        "context": ["evidence"],
+                        "multiple_choice_answers": {
+                            f"answer_{number}": {"text": f"choice {number}"}
+                            for number in range(1, 4)
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+
+class CouncilSchemaTests(unittest.TestCase):
+    def test_accepts_valid_generated_briefing(self):
+        validate_council_briefing(
+            valid_briefing(), expected_date="2026-06-16", generated=True
+        )
+
+    def test_rejects_topic_nested_as_deliberation_item(self):
+        data = valid_briefing()
+        data["key_points"][0]["deliberation_items"].append(
+            {"topic": "nested topic", "summary": "wrong level"}
+        )
+
+        with self.assertRaisesRegex(CouncilValidationError, "question_id"):
+            validate_council_briefing(data, generated=True)
+        with self.assertRaisesRegex(CouncilValidationError, "question_id"):
+            validate_consumer_contract(data)
+
+    def test_rejects_duplicate_question_ids(self):
+        data = valid_briefing()
+        duplicate = copy.deepcopy(data["key_points"][0]["deliberation_items"][0])
+        data["key_points"][0]["deliberation_items"].append(duplicate)
+
+        with self.assertRaisesRegex(CouncilValidationError, "duplicate question_id"):
+            validate_council_briefing(data, generated=True)
+
+    def test_published_briefing_allows_other_answer(self):
+        data = valid_briefing()
+        data["key_points"][0]["deliberation_items"][0][
+            "multiple_choice_answers"
+        ]["answer_4"] = {"text": "Other", "implication": None}
+
+        validate_council_briefing(data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/etl/validate-council-briefing.py
+++ b/scripts/etl/validate-council-briefing.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Validate one or more council briefing files against the V2 consumer contract."""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from council_schema import (
+    CouncilValidationError,
+    is_legacy_briefing,
+    validate_consumer_contract,
+    validate_council_briefing,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("paths", nargs="+", type=Path)
+    parser.add_argument(
+        "--allow-legacy",
+        action="store_true",
+        help="Skip valid pre-V2 briefings when scanning historical data",
+    )
+    parser.add_argument(
+        "--consumer-only",
+        action="store_true",
+        help="Check fields dereferenced by consumers across mixed historical schemas",
+    )
+    args = parser.parse_args()
+
+    failed = False
+    for path in args.paths:
+        try:
+            data = json.loads(path.read_text())
+            if args.consumer_only:
+                validate_consumer_contract(data)
+                print(f"OK: {path}")
+                continue
+            if args.allow_legacy and is_legacy_briefing(data):
+                print(f"SKIP legacy: {path}")
+                continue
+            expected_date = None if path.name == "daily.json" else path.stem
+            validate_council_briefing(data, expected_date=expected_date)
+            print(f"OK: {path}")
+        except (OSError, json.JSONDecodeError, CouncilValidationError) as error:
+            print(f"INVALID: {path}: {error}", file=sys.stderr)
+            failed = True
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/the-council/council_briefing/2026-06-16.json
+++ b/the-council/council_briefing/2026-06-16.json
@@ -27,6 +27,10 @@
             "answer_3": {
               "text": "Scope the launch to a local private alpha until token issues resolve.",
               "implication": "Minimizes blast radius while allowing 'Developer First' feedback to continue."
+            },
+            "answer_4": {
+              "text": "Other / More discussion needed / None of the above.",
+              "implication": null
             }
           }
         },
@@ -49,6 +53,10 @@
             "answer_3": {
               "text": "Deprioritize Windows UI fixes until the Cloud stability mission is complete.",
               "implication": "Risks community churn but maintains focus on the Monthly Directive."
+            },
+            "answer_4": {
+              "text": "Other / More discussion needed / None of the above.",
+              "implication": null
             }
           }
         }
@@ -77,14 +85,20 @@
             "answer_3": {
               "text": "Host an immediate 'Town Hall' via Twitter Spaces to address financial allegations.",
               "implication": "Provides immediate human trust but risks validating unverified claims."
+            },
+            "answer_4": {
+              "text": "Other / More discussion needed / None of the above.",
+              "implication": null
             }
           }
-        },
+        }
+      ]
+    },
+    {
+      "topic": "The 'Semantic Delegation' Opportunity",
+      "summary": "The proposal from Saulodigital for ERC-7710/Intuition integration offers a path to the 'Decentralized AI Economy' goal but requires deep technical coordination.",
+      "deliberation_items": [
         {
-          "topic": "The 'Semantic Delegation' Opportunity",
-          "summary": "The proposal from Saulodigital for ERC-7710/Intuition integration offers a path to the 'Decentralized AI Economy' goal but requires deep technical coordination.",
-          "deliberation_items": [
-            {
               "question_id": "q4",
               "text": "Is elizaOS ready to adopt an external Knowledge Graph (Intuition) as a primary authority layer for agent delegation?",
               "context": [
@@ -103,11 +117,13 @@
                 "answer_3": {
                   "text": "Reject external dependency in favor of a native Eliza-native trust score system.",
                   "implication": "Maintains total autonomy but isolates the ecosystem from broader Ethereum standard stacks."
+                },
+                "answer_4": {
+                  "text": "Other / More discussion needed / None of the above.",
+                  "implication": null
                 }
               }
             }
-          ]
-        }
       ]
     }
   ]


### PR DESCRIPTION
## What changed

- repair the malformed 2026-06-16 council briefing by moving the nested topic back into `key_points`
- add reusable strict and consumer-facing council briefing validators
- validate generated output before publishing dated files or `daily.json`
- preserve existing output on model, schema, empty-input, or stale-date failures
- write successful generated files atomically
- make council backfills detect and regenerate invalid files while skipping healthy data
- gate GitHub Pages publication on the consumer contract
- add regression coverage for nested topics, duplicate IDs, and published answer options

## Root cause

The LLM returned valid JSON with a topic object nested inside `deliberation_items`. Existing validation rejected it, but the rejected object remained truthy, so the generator's `finally` block selected and wrote it anyway. Astro later called `item.question_id.toUpperCase()` on that nested topic and crashed every build that traversed the file.

The pipeline could also publish stale `daily.json` aggregate data under a newer dated output path.

## Impact

Malformed generated data now fails before publication without replacing the last healthy briefing. Historical files can be scanned for the exact fields used by the Astro renderer, and repair backfills regenerate only invalid V2 data.

After merge, elizaos.news should run a full Astro rebuild to backfill the pages missed since June 16.

## Validation

- `python -m unittest discover -s scripts/etl -p 'test_*.py'`
- `python -m py_compile scripts/etl/council_schema.py scripts/etl/validate-council-briefing.py scripts/etl/generate-council-context.py`
- consumer-contract validation across all 534 briefing JSON files
- `bash -n scripts/etl/backfill/backfill-council.sh`
- `git diff --check`
- stale aggregate/output date simulation confirms no output is written
